### PR TITLE
fix: add mypy.ini file to ignore warnings from scipy.linalg

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy-scipy.linalg.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Mypy type checking was giving issues with the scipy.linalg package.

Added a mypy.ini file with an option to ignore missing imports from scipy.linalg